### PR TITLE
[ Add ] added stream-based chat completion creation for the SDK

### DIFF
--- a/example/lib/chat_campletion_stream_example.dart
+++ b/example/lib/chat_campletion_stream_example.dart
@@ -6,7 +6,7 @@ void main() {
   // Set the OpenAI API key from the .env file.
   OpenAI.apiKey = Env.apiKey;
 
-  // Creates A Stream Of Completions text.
+  // Creates A Stream Of Chat Completions.
   final stream = OpenAI.instance.chat.createStream(
     model: "gpt-3.5-turbo",
     messages: [
@@ -18,7 +18,7 @@ void main() {
   );
 
   var answer = "";
-  // listen to the stream and print the text.
+  // listen to the stream and print the content.
   stream.listen(
     (event) {
       final delta = event.choices.first.delta;

--- a/example/lib/chat_campletion_stream_example.dart
+++ b/example/lib/chat_campletion_stream_example.dart
@@ -1,0 +1,32 @@
+import 'package:dart_openai/openai.dart';
+
+import 'env/env.dart';
+
+void main() {
+  // Set the OpenAI API key from the .env file.
+  OpenAI.apiKey = Env.apiKey;
+
+  // Creates A Stream Of Completions text.
+  final stream = OpenAI.instance.chat.createStream(
+    model: "gpt-3.5-turbo",
+    messages: [
+      OpenAIChatCompletionChoiceMessageModel(
+        content: "hello",
+        role: "user",
+      )
+    ],
+  );
+
+  var answer = "";
+  // listen to the stream and print the text.
+  stream.listen(
+    (event) {
+      final delta = event.choices.first.delta;
+      print(delta.toString());
+      if (delta.content != null) {
+        answer += delta.content!;
+      }
+    },
+    onDone: () => print(answer),
+  );
+}

--- a/lib/src/core/base/chat/interfaces/create.dart
+++ b/lib/src/core/base/chat/interfaces/create.dart
@@ -1,7 +1,21 @@
-import '../../../models/chat/sub_models/choices/sub_models/message.dart';
+import '../../../models/chat/chat.dart';
 
 abstract class CreateInterface {
-  Future create({
+  Future<OpenAIChatCompletionModel> create({
+    required String model,
+    required List<OpenAIChatCompletionChoiceMessageModel> messages,
+    double? temperature,
+    double? topP,
+    int? n,
+    dynamic stop,
+    int? maxTokens,
+    double? presencePenalty,
+    double? frequencyPenalty,
+    Map<String, dynamic>? logitBias,
+    String? user,
+  });
+
+  Stream<OpenAIStreamChatCompletionModel> createStream({
     required String model,
     required List<OpenAIChatCompletionChoiceMessageModel> messages,
     double? temperature,

--- a/lib/src/core/models/chat/chat.dart
+++ b/lib/src/core/models/chat/chat.dart
@@ -5,6 +5,7 @@ import 'sub_models/usage.dart';
 
 export 'sub_models/usage.dart';
 export 'sub_models/choices/choices.dart';
+export 'stream/chat.dart';
 
 class OpenAIChatCompletionModel {
   /// The [id] of the chat completion.

--- a/lib/src/core/models/chat/stream/chat.dart
+++ b/lib/src/core/models/chat/stream/chat.dart
@@ -1,0 +1,54 @@
+import 'package:collection/collection.dart';
+
+import 'sub_models/choices/choices.dart';
+
+export 'sub_models/choices/choices.dart';
+export 'sub_models/usage.dart';
+
+class OpenAIStreamChatCompletionModel {
+  /// The [id] of the chat completion.
+  final String id;
+
+  /// The date and time when the chat completion is [created].
+  final DateTime created;
+
+  /// The [choices] of the chat completion.
+  final List<OpenAIStreamChatCompletionChoiceModel> choices;
+
+  @override
+  int get hashCode {
+    return id.hashCode ^ created.hashCode ^ choices.hashCode;
+  }
+
+  OpenAIStreamChatCompletionModel({
+    required this.id,
+    required this.created,
+    required this.choices,
+  });
+
+  factory OpenAIStreamChatCompletionModel.fromJson(Map<String, dynamic> json) {
+    return OpenAIStreamChatCompletionModel(
+      id: json['id'],
+      created: DateTime.fromMillisecondsSinceEpoch(json['created'] * 1000),
+      choices: (json['choices'] as List)
+          .map((e) => OpenAIStreamChatCompletionChoiceModel.fromJson(e))
+          .toList(),
+    );
+  }
+
+  @override
+  String toString() {
+    return 'OpenAIChatCompletionModel(id: $id, created: $created, choices: $choices)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    const ListEquality listEquals = ListEquality();
+    if (identical(this, other)) return true;
+
+    return other is OpenAIStreamChatCompletionModel &&
+        other.id == id &&
+        other.created == created &&
+        listEquals.equals(other.choices, choices);
+  }
+}

--- a/lib/src/core/models/chat/stream/chat.dart
+++ b/lib/src/core/models/chat/stream/chat.dart
@@ -38,7 +38,7 @@ class OpenAIStreamChatCompletionModel {
 
   @override
   String toString() {
-    return 'OpenAIChatCompletionModel(id: $id, created: $created, choices: $choices)';
+    return 'OpenAIStreamChatCompletionModel(id: $id, created: $created, choices: $choices)';
   }
 
   @override

--- a/lib/src/core/models/chat/stream/sub_models/choices/choices.dart
+++ b/lib/src/core/models/chat/stream/sub_models/choices/choices.dart
@@ -1,0 +1,42 @@
+import 'sub_models/delta.dart';
+
+class OpenAIStreamChatCompletionChoiceModel {
+  final int index;
+  final OpenAIStreamChatCompletionChoiceDeltaModel delta;
+  final String? finishReason;
+
+  @override
+  int get hashCode {
+    return index.hashCode ^ delta.hashCode ^ finishReason.hashCode;
+  }
+
+  OpenAIStreamChatCompletionChoiceModel({
+    required this.index,
+    required this.delta,
+    required this.finishReason,
+  });
+
+  factory OpenAIStreamChatCompletionChoiceModel.fromJson(
+      Map<String, dynamic> json) {
+    return OpenAIStreamChatCompletionChoiceModel(
+      index: json['index'],
+      delta: OpenAIStreamChatCompletionChoiceDeltaModel.fromJson(json['delta']),
+      finishReason: json['finish_reason'],
+    );
+  }
+
+  @override
+  String toString() {
+    return 'OpenAIChatCompletionChoiceModel(index: $index, delta: $delta, finishReason: $finishReason)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is OpenAIStreamChatCompletionChoiceModel &&
+        other.index == index &&
+        other.delta == delta &&
+        other.finishReason == finishReason;
+  }
+}

--- a/lib/src/core/models/chat/stream/sub_models/choices/choices.dart
+++ b/lib/src/core/models/chat/stream/sub_models/choices/choices.dart
@@ -17,7 +17,8 @@ class OpenAIStreamChatCompletionChoiceModel {
   });
 
   factory OpenAIStreamChatCompletionChoiceModel.fromJson(
-      Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+  ) {
     return OpenAIStreamChatCompletionChoiceModel(
       index: json['index'],
       delta: OpenAIStreamChatCompletionChoiceDeltaModel.fromJson(json['delta']),
@@ -27,7 +28,7 @@ class OpenAIStreamChatCompletionChoiceModel {
 
   @override
   String toString() {
-    return 'OpenAIChatCompletionChoiceModel(index: $index, delta: $delta, finishReason: $finishReason)';
+    return 'OpenAIStreamChatCompletionChoiceModel(index: $index, delta: $delta, finishReason: $finishReason)';
   }
 
   @override

--- a/lib/src/core/models/chat/stream/sub_models/choices/sub_models/delta.dart
+++ b/lib/src/core/models/chat/stream/sub_models/choices/sub_models/delta.dart
@@ -1,0 +1,43 @@
+class OpenAIStreamChatCompletionChoiceDeltaModel {
+  final String? role;
+  final String? content;
+
+  @override
+  int get hashCode {
+    return role.hashCode ^ content.hashCode;
+  }
+
+  OpenAIStreamChatCompletionChoiceDeltaModel({
+    required this.role,
+    required this.content,
+  });
+
+  factory OpenAIStreamChatCompletionChoiceDeltaModel.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return OpenAIStreamChatCompletionChoiceDeltaModel(
+      role: json['role'],
+      content: json['content'],
+    );
+  }
+  Map<String, dynamic> toMap() {
+    return {
+      "role": role,
+      "content": content,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'OpenAIChatCompletionChoiceMessageModel(role: $role, content: $content)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is OpenAIStreamChatCompletionChoiceDeltaModel &&
+        other.role == role &&
+        other.content == content;
+  }
+}

--- a/lib/src/core/models/chat/stream/sub_models/choices/sub_models/delta.dart
+++ b/lib/src/core/models/chat/stream/sub_models/choices/sub_models/delta.dart
@@ -29,7 +29,7 @@ class OpenAIStreamChatCompletionChoiceDeltaModel {
 
   @override
   String toString() {
-    return 'OpenAIChatCompletionChoiceMessageModel(role: $role, content: $content)';
+    return 'OpenAIStreamChatCompletionChoiceMessageModel(role: $role, content: $content)';
   }
 
   @override

--- a/lib/src/core/models/chat/stream/sub_models/usage.dart
+++ b/lib/src/core/models/chat/stream/sub_models/usage.dart
@@ -1,0 +1,44 @@
+export 'choices/sub_models/delta.dart';
+
+class OpenAIStreamChatCompletionUsageModel {
+  final int promptTokens;
+  final int completionTokens;
+  final int totalTokens;
+
+  @override
+  int get hashCode {
+    return promptTokens.hashCode ^
+        completionTokens.hashCode ^
+        totalTokens.hashCode;
+  }
+
+  OpenAIStreamChatCompletionUsageModel({
+    required this.promptTokens,
+    required this.completionTokens,
+    required this.totalTokens,
+  });
+
+  factory OpenAIStreamChatCompletionUsageModel.fromJson(
+      Map<String, dynamic> json) {
+    return OpenAIStreamChatCompletionUsageModel(
+      promptTokens: json['prompt_tokens'],
+      completionTokens: json['completion_tokens'],
+      totalTokens: json['total_tokens'],
+    );
+  }
+
+  @override
+  String toString() {
+    return 'OpenAIChatCompletionUsageModel(promptTokens: $promptTokens, completionTokens: $completionTokens, totalTokens: $totalTokens)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is OpenAIStreamChatCompletionUsageModel &&
+        other.promptTokens == promptTokens &&
+        other.completionTokens == completionTokens &&
+        other.totalTokens == totalTokens;
+  }
+}

--- a/lib/src/instance/chat/chat.dart
+++ b/lib/src/instance/chat/chat.dart
@@ -3,7 +3,6 @@ import 'package:dart_openai/src/core/networking/client.dart';
 
 import '../../core/base/chat/chat.dart';
 import '../../core/models/chat/chat.dart';
-import '../../core/models/chat/sub_models/choices/sub_models/message.dart';
 
 class OpenAIChat implements OpenAIChatBase {
   @override
@@ -74,6 +73,74 @@ class OpenAIChat implements OpenAIChatBase {
       },
       onSuccess: (Map<String, dynamic> response) {
         return OpenAIChatCompletionModel.fromJson(response);
+      },
+    );
+  }
+
+  /// This function creates a completion [Stream]  of [OpenAIChatCompletionModel], which it does stream the results as they are generated.
+  ///
+  /// [model] is the model to use for completion.
+  ///
+  /// [messages] is the list of messages to complete from, note you need to set each message as a [OpenAIChatCompletionChoiceMessageModel] object.
+  ///
+  /// [temperature] is the value controlling randomness in boltzmann
+  ///
+  /// [topP] is the cumulative probability for top-k filtering
+  ///
+  /// [n] is the number of results to return
+  ///
+  /// [stop] is the sequence to stop on. Overrides [maxTokens].
+  ///
+  /// [maxTokens] is the maximum number of tokens to generate.
+  ///
+  /// [presencePenalty] is the penalty for tokens already in the sequence.
+  ///
+  /// [frequencyPenalty] is the penalty for existing words in the sequence.
+  ///
+  /// [logitBias] is the token to bias the logit towards.
+  ///
+  /// [user] is the user ID to use for the completion.
+  ///
+  /// Example:
+  /// ```dart
+  /// final chatCompletion Stream = OpenAI.instance.chat.createStream(
+  /// model: "gpt-3.5-turbo",
+  /// messages: [
+  ///   OpenAIChatCompletionChoiceMessageModel(content: "hello, what is Flutter and Dart ?", role: "user")
+  /// ]);
+  /// ```
+  @override
+  Stream<OpenAIStreamChatCompletionModel> createStream({
+    required String model,
+    required List<OpenAIChatCompletionChoiceMessageModel> messages,
+    double? temperature,
+    double? topP,
+    int? n,
+    stop,
+    int? maxTokens,
+    double? presencePenalty,
+    double? frequencyPenalty,
+    Map<String, dynamic>? logitBias,
+    String? user,
+  }) {
+    return OpenAINetworkingClient.postStream<OpenAIStreamChatCompletionModel>(
+      to: BaseApiUrlBuilder.build(endpoint),
+      body: {
+        "model": model,
+        "stream": true,
+        "messages": messages.map((message) => message.toMap()).toList(),
+        if (temperature != null) "temperature": temperature,
+        if (topP != null) "top_p": topP,
+        if (n != null) "n": n,
+        if (stop != null) "stop": stop,
+        if (maxTokens != null) "max_tokens": maxTokens,
+        if (presencePenalty != null) "presence_penalty": presencePenalty,
+        if (frequencyPenalty != null) "frequency_penalty": frequencyPenalty,
+        if (logitBias != null) "logit_bias": logitBias,
+        if (user != null) "user": user,
+      },
+      onSuccess: (Map<String, dynamic> response) {
+        return OpenAIStreamChatCompletionModel.fromJson(response);
       },
     );
   }

--- a/lib/src/instance/chat/chat.dart
+++ b/lib/src/instance/chat/chat.dart
@@ -77,7 +77,7 @@ class OpenAIChat implements OpenAIChatBase {
     );
   }
 
-  /// This function creates a completion [Stream]  of [OpenAIChatCompletionModel], which it does stream the results as they are generated.
+  /// This function creates a completion [Stream]  of [OpenAIStreamChatCompletionModel], which it does stream the results as they are generated.
   ///
   /// [model] is the model to use for completion.
   ///

--- a/test/openai_test.dart
+++ b/test/openai_test.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:http/http.dart' as http;
 import 'package:dart_openai/openai.dart';
+import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
 void main() async {
@@ -137,6 +137,18 @@ void main() async {
         isA<OpenAIChatCompletionChoiceMessageModel>(),
       );
       expect(chatCompletion.choices.first.message.content, isA<String>());
+    });
+    test('create with a stream', () {
+      final completion = OpenAI.instance.chat.createStream(
+        model: "gpt-3.5-turbo",
+        messages: [
+          OpenAIChatCompletionChoiceMessageModel(
+            content: "Hello, how are you?",
+            role: "user",
+          ),
+        ],
+      );
+      expect(completion, isA<Stream<OpenAIChatCompletionModel>>());
     });
   });
   group('edits', () {


### PR DESCRIPTION
I tried implementing a Chat stream by referring to the code for OpenAI.instance.completion.createStream.

The below is the log of executing the example(chat_campletion_stream_example.dart).
```
OpenAIStreamChatCompletionChoiceMessageModel(role: assistant, content: null)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content: 

)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content: Hi)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content:  there)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content: !)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content:  How)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content:  can)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content:  I)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content:  assist)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content:  you)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content:  today)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content: ?)
OpenAIStreamChatCompletionChoiceMessageModel(role: null, content: null)


Hi there! How can I assist you today?
```