### PR TITLE
Fixes chat completion stream losing first event data

### DIFF
--- a/lib/src/core/networking/client.dart
+++ b/lib/src/core/networking/client.dart
@@ -3,9 +3,9 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_openai/openai.dart';
-import 'package:http/http.dart' as http;
 import 'package:dart_openai/src/core/builder/headers.dart';
 import 'package:dart_openai/src/core/utils/logger.dart';
+import 'package:http/http.dart' as http;
 
 import '../exceptions/request_failure.dart';
 
@@ -192,9 +192,14 @@ class OpenAINetworkingClient {
     client.send(request).then(
       (respond) {
         OpenAILogger.log("Starting to reading stream response");
-        respond.stream.listen(
+
+        final stream = respond.stream
+            .transform(utf8.decoder)
+            .transform(const LineSplitter());
+
+        stream.listen(
           (value) {
-            final String data = utf8.decode(value);
+            final data = value;
 
             final List<String> dataLines = data
                 .split("\n")


### PR DESCRIPTION
During my testing, sometimes, the first stream data event contains two data objects. The parser seems to need to split them correctly, and one gets lost.  This is related to some comments mentioned in #11, which I was able to replicate.

There might be something that is being aggravated by the `OpenAILogger.log`. Whenever I missed a data event, the output of the log would only display after the missed data event. I did not dig much into it, but the transform of the stream did the trick for me.

I have been able to replicate the issue consistently. The following way.

User: Hi
Response: ...

User: Hello
Response: ...

User: How are you?
Response:...

Within those three responses, one of them would miss the first word.



