### PR TITLE
[Fix] fix bug ignoring subsequent data in stream event

### DIFF
--- a/lib/src/core/networking/client.dart
+++ b/lib/src/core/networking/client.dart
@@ -214,7 +214,7 @@ class OpenAINetworkingClient {
 
                 controller.add(onSuccess(decoded));
 
-                return;
+                continue;
               }
               final error = jsonDecode(data)['error'];
               if (error != null) {


### PR DESCRIPTION
Currently, when a stream data event contains multiple data, only the first data is being parsed and processed, while the rest are being ignored. This results in incomplete processing of the stream data event.

Perhaps this issue #16 is caused by the same thing.
I had the same situation and when I checked the behavior in flutter web, I found the aforementioned problem.

The bug was caused by an incorrect return statement in the parsing code for stream data events, which caused the code to exit prematurely and prevented the processing of subsequent data in the event. To fix this, I replaced the return statement with a continue statement, allowing the code to continue processing subsequent data in the stream data event.
 
Sorry if this is hard to understand since it is a machine translation.
Please review and let me know if you have any feedback or suggestions.
Thank you.