### PR TITLE
display more error details when postStream failed

### DIFF
--- a/lib/src/core/networking/client.dart
+++ b/lib/src/core/networking/client.dart
@@ -291,7 +291,8 @@ abstract final class OpenAINetworkingClient {
                 if (doesErrorExists(decodedData)) {
                   final error = decodedData[OpenAIStrings.errorFieldKey]
                       as Map<String, dynamic>;
-                  final message = jsonEncode(error);
+                  final message = error[OpenAIStrings.messageFieldKey] as String;
+                  message = message.isEmpty ? jsonEncode(error) : message;
                   final statusCode = respond.statusCode;
                   final exception = RequestFailedException(message, statusCode);
 

--- a/lib/src/core/networking/client.dart
+++ b/lib/src/core/networking/client.dart
@@ -291,7 +291,7 @@ abstract final class OpenAINetworkingClient {
                 if (doesErrorExists(decodedData)) {
                   final error = decodedData[OpenAIStrings.errorFieldKey]
                       as Map<String, dynamic>;
-                  final message = error[OpenAIStrings.messageFieldKey];
+                  final message = jsonEncode(error);
                   final statusCode = respond.statusCode;
                   final exception = RequestFailedException(message, statusCode);
 

--- a/lib/src/core/networking/client.dart
+++ b/lib/src/core/networking/client.dart
@@ -291,7 +291,7 @@ abstract final class OpenAINetworkingClient {
                 if (doesErrorExists(decodedData)) {
                   final error = decodedData[OpenAIStrings.errorFieldKey]
                       as Map<String, dynamic>;
-                  final message = error[OpenAIStrings.messageFieldKey] as String;
+                  var message = error[OpenAIStrings.messageFieldKey] as String;
                   message = message.isEmpty ? jsonEncode(error) : message;
                   final statusCode = respond.statusCode;
                   final exception = RequestFailedException(message, statusCode);


### PR DESCRIPTION
when use  a deactivated account's api key to createStream 

```dart
    final chatStream = OpenAI.instance.chat.createStream(
      model: "gpt-3.5-turbo",
      temperature: temperature,
      messages: messages,
    );
```

openai backend will return:
```
{
    "message":"",
    "type":"invalid_request_error",
    "param":null,
    "code":"account_deactivated"
}
```

**Note: the message is empty.**

 in this lib, RequestFailedException.message will empty, the developer can only obtain the network request status code :
```dart
                if (doesErrorExists(decodedData)) {
                  final error = decodedData[OpenAIStrings.errorFieldKey]
                      as Map<String, dynamic>;
                  final message = error[OpenAIStrings.messageFieldKey];
                  final statusCode = respond.statusCode;
                  final exception = RequestFailedException(message, statusCode);

                  controller.addError(exception);
                }
```

This PR does the following:

```dart
final message = error[OpenAIStrings.messageFieldKey];
```
change to

```dart
final message = jsonEncode(error);
```





