### PR TITLE
Use http 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_openai
 description: Dart SDK for openAI Apis (GPT-3 & DALL-E), integrate easily the power of OpenAI's state-of-the-art AI models into their Dart applications.
-version: 1.9.93
+version: 1.10.0
 homepage: https://github.com/anasfik/openai
 repository: https://github.com/anasfik/openai
 documentation: https://github.com/anasfik/openai/blob/main/README.md
@@ -15,7 +15,7 @@ dev_dependencies:
   test: ^1.16.0
 
 dependencies:
-  http: ^0.13.5
+  http: ^1.0.0
   meta: ^1.8.0
   collection: ^1.17.0
   fetch_client: ^1.0.0


### PR DESCRIPTION
Since SDK is already at >=3.0.0, doesn't seem to be a breaking change