### PR TITLE
[ Fix ] fixed stream mode can't handle error

### DIFF
--- a/lib/src/core/networking/client.dart
+++ b/lib/src/core/networking/client.dart
@@ -275,9 +275,11 @@ abstract class OpenAINetworkingClient {
               .transform(utf8.decoder)
               .transform(openAIChatStreamLineSplitter);
 
+          String respondData = "";
           stream.listen(
             (value) {
               final data = value;
+              respondData += data;
 
               final dataLines = data
                   .split("\n")
@@ -300,7 +302,10 @@ abstract class OpenAINetworkingClient {
                   continue;
                 }
 
-                final decodedData = decodeToMap(data);
+                Map<String, dynamic> decodedData = {};
+                try {
+                  decodedData = decodeToMap(respondData);
+                } catch (error) {/** ignore, data has not been received */}
 
                 if (doesErrorExists(decodedData)) {
                   final error = decodedData[OpenAIStrings.errorFieldKey]


### PR DESCRIPTION
Since the error response in stream mode is not received at one time, it needs to be spliced together and then decoded, otherwise the decode will always fail