### PR TITLE
Add Timeout and Credit exceptions based on returned header values from each request

### DIFF
--- a/lib/src/core/exceptions/request_failure.dart
+++ b/lib/src/core/exceptions/request_failure.dart
@@ -19,3 +19,19 @@ class RequestFailedException implements Exception {
     return 'RequestFailedException{message: $message, statusCode: $statusCode}';
   }
 }
+
+/// This exception is thrown when OpenAI returns 429 Rate Limited, due to too-many-requests
+class RateLimitedException extends RequestFailedException {
+  /// Length of time before the API key becomes unlocked for further calls
+  final Duration timedOutDuration;
+
+  /// Timestamp of when the API key will become unlocked for further calls
+  final DateTime timedOutUntil;
+
+  RateLimitedException(super.message, super.statusCode, this.timedOutDuration, this.timedOutUntil);
+}
+
+/// This exception is thrown when OpenAI returns 429 Rate Limited, due to no more credits
+class OutOfCreditsException extends RequestFailedException {
+  OutOfCreditsException(super.message, super.statusCode);
+}


### PR DESCRIPTION
This PR adds two new sub-type exceptions of RequestFailedException:

* OutOfCreditsException  
* RateLimitedException

These exceptions are returned by parsing the response headers for 'x-ratelimit-reset-requests' and 'x-ratelimit-remaining-requests'. 

To make this change maintainable, the PR also refactors how errors are decoded across the major client methods