### PR TITLE
fix: conditional import using `dart.library.js`

### DIFF
--- a/lib/src/core/networking/client.dart
+++ b/lib/src/core/networking/client.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "dart:io";
 // ignore: unused_import
 import "package:dart_openai/src/core/utils/http_client_web.dart"
+    if (dart.library.js) "package:dart_openai/src/core/utils/http_client_io.dart"
     if (dart.library.io) "package:dart_openai/src/core/utils/http_client_io.dart";
 
 import 'package:dart_openai/dart_openai.dart';


### PR DESCRIPTION
The use of `fetch_api` is causing issues in non-html environments, this PR adds a condition for it to use the io import instead.

This would make it possible to use this package with Dart Edge, see #34.