### PR TITLE
fix: The type in OpenAIChatCompletionChoiceMessageContentItemModel.im…

### DIFF
--- a/lib/src/core/models/chat/sub_models/choices/sub_models/sub_models/content.dart
+++ b/lib/src/core/models/chat/sub_models/choices/sub_models/sub_models/content.dart
@@ -46,7 +46,7 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
     String imageUrl,
   ) {
     return OpenAIChatCompletionChoiceMessageContentItemModel._(
-      type: 'image',
+      type: 'image_url',
       imageUrl: imageUrl,
     );
   }


### PR DESCRIPTION
The type in OpenAIChatCompletionChoiceMessageContentItemModel.imageUrl() should be "image_url".

api docs: https://platform.openai.com/docs/api-reference/chat/create
```
curl https://api.openai.com/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
    "model": "gpt-4-vision-preview",
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "What’s in this image?"
          },
          {
            "type": "image_url",
            "image_url": {
              "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
            }
          }
        ]
      }
    ],
    "max_tokens": 300
  }'
```