### PR TITLE
Remove toolChoice from ChatGpt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,6 @@ OpenAIChatCompletionModel chatCompletion = await OpenAI.instance.chat.create(
   messages: requestMessages,
   temperature: 0.2,
   maxTokens: 500,
-  toolChoice: "auto",
 );
 
 print(chatCompletion.choices.first.message); // ...


### PR DESCRIPTION
Remove toolChoice from chatGpt example, as this example does not work when having toolChoice as a String.