### PR TITLE
Added imageBase64 capability instead of Image URL only for gpt-4-vision

### DIFF
--- a/lib/src/core/models/chat/sub_models/choices/sub_models/sub_models/content.dart
+++ b/lib/src/core/models/chat/sub_models/choices/sub_models/sub_models/content.dart
@@ -12,6 +12,8 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
   /// The image url content of the item.
   final String? imageUrl;
 
+  final String? imageBase64;
+
   @override
   int get hashCode => type.hashCode ^ text.hashCode ^ imageUrl.hashCode;
 
@@ -20,6 +22,7 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
     required this.type,
     this.text,
     this.imageUrl,
+    this.imageBase64,
   });
 
   /// This is used to convert a [Map<String, dynamic>] object to a [OpenAIChatCompletionChoiceMessageContentItemModel] object.
@@ -30,6 +33,7 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
       type: asMap['type'],
       text: asMap['text'],
       imageUrl: asMap['image_url'],
+      imageBase64: asMap['imageBase64'],
     );
   }
 
@@ -51,12 +55,22 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
     );
   }
 
+  factory OpenAIChatCompletionChoiceMessageContentItemModel.imageBase64(
+    String imageBase64,
+  ) {
+    return OpenAIChatCompletionChoiceMessageContentItemModel._(
+      type: 'image_base64',
+      imageBase64: imageBase64,
+    );
+  }
+
   /// This method used to convert the [OpenAIChatCompletionChoiceMessageContentItemModel] to a [Map<String, dynamic>] object.
   Map<String, dynamic> toMap() {
     return {
       "type": type,
       if (text != null) "text": text,
       if (imageUrl != null) "image_url": imageUrl,
+      if (imageBase64 != null) "image_url": {"url": "data:image/jpeg;base64,${imageBase64}"}
     };
   }
 
@@ -68,7 +82,8 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
 
     return other.type == type &&
         other.text == text &&
-        other.imageUrl == imageUrl;
+        other.imageUrl == imageUrl &&
+        other.imageBase64 == imageBase64;
   }
 
   @override
@@ -77,6 +92,8 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
           'OpenAIChatCompletionChoiceMessageContentItemModel(type: $type, text: $text)',
         'image' =>
           'OpenAIChatCompletionChoiceMessageContentItemModel(type: $type, imageUrl: $imageUrl)',
+          'image_base64' =>
+          'OpenAIChatCompletionChoiceMessageContentItemModel(type: $type, imageBase64: $imageBase64)',
         _ => 'OpenAIChatCompletionChoiceMessageContentItemModel(type: $type)',
       };
 }


### PR DESCRIPTION
Hi @anasfik , I have added capability for image base 64 on OpenAIChatCompletionChoiceMessageContentItemModel instead of URL only for this merge request. 

This functionality will support image from local through base64 encoding.

hope this helps! thank you