### PR TITLE
Changed JSON Syntax for imageUrls to have a object instead of a String.

### DIFF
--- a/lib/src/core/models/chat/sub_models/choices/sub_models/sub_models/content.dart
+++ b/lib/src/core/models/chat/sub_models/choices/sub_models/sub_models/content.dart
@@ -10,16 +10,20 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
   final String? text;
 
   /// The image url content of the item.
-  final String? imageUrl;
+  final String? url;
+
+  /// The image url object.
+  final Map<String, dynamic>? imageUrl;
 
   @override
-  int get hashCode => type.hashCode ^ text.hashCode ^ imageUrl.hashCode;
+  int get hashCode => type.hashCode ^ text.hashCode ^ imageUrl.hashCode ^ url.hashCode;
 
   /// {@macro openai_chat_completion_choice_message_content_item_model}
   OpenAIChatCompletionChoiceMessageContentItemModel._({
     required this.type,
     this.text,
     this.imageUrl,
+    this.url
   });
 
   /// This is used to convert a [Map<String, dynamic>] object to a [OpenAIChatCompletionChoiceMessageContentItemModel] object.
@@ -30,6 +34,7 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
       type: asMap['type'],
       text: asMap['text'],
       imageUrl: asMap['image_url'],
+      url: asMap['url']
     );
   }
 
@@ -47,7 +52,7 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
   ) {
     return OpenAIChatCompletionChoiceMessageContentItemModel._(
       type: 'image_url',
-      imageUrl: imageUrl,
+      imageUrl: {'url': imageUrl},
     );
   }
 


### PR DESCRIPTION
When constructing a message using the `OpenAIChatCompletionChoiceMessageContentItemModel.imageUrl` constructor the JSON is built wrong. Image Requests require a JSON object for imageUrl not a String.

The JSON should have this format: `imageUrl: {url: 'imageUrl'}` not `imageUrl: 'imageUrl'`.

I guess there might be an existing solution/workaround for this, or they changed the API syntax, but this is the solution that worked for me.