### PR TITLE
Example of getting bytes instead of saving directly to file for speech

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -159,7 +159,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.1.4"
+    version: "5.1.0"
   dart_style:
     dependency: transitive
     description:

--- a/lib/src/core/base/audio/interfaces.dart
+++ b/lib/src/core/base/audio/interfaces.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import '../../../../dart_openai.dart';
 
@@ -11,6 +12,14 @@ abstract class CreateInterface {
     double? speed,
     String outputFileName = "output",
     Directory? outputDirectory,
+  });
+
+  Future<Uint8List> createSpeechBytes({
+    required String model,
+    required String input,
+    required String voice,
+    OpenAIAudioSpeechResponseFormat? responseFormat,
+    double? speed,
   });
 
   Future<OpenAIAudioModel> createTranscription({

--- a/lib/src/instance/audio/audio.dart
+++ b/lib/src/instance/audio/audio.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:dart_openai/src/core/builder/base_api_url.dart';
 import 'package:dart_openai/src/core/networking/client.dart';
 
@@ -149,6 +151,26 @@ interface class OpenAIAudio implements OpenAIAudioBase {
       },
       outputFileName: outputFileName,
       outputDirectory: outputDirectory,
+    );
+  }
+
+  @override
+  Future<Uint8List> createSpeechBytes({
+    required String model,
+    required String input,
+    required String voice,
+    OpenAIAudioSpeechResponseFormat? responseFormat,
+    double? speed,
+  }) async {
+    return await OpenAINetworkingClient.postAndGetBytes(
+      to: BaseApiUrlBuilder.build(endpoint + "/speech"),
+      body: {
+        "model": model,
+        "input": input,
+        "voice": voice,
+        if (responseFormat != null) "response_format": responseFormat.name,
+        if (speed != null) "speed": speed,
+      },
     );
   }
 }


### PR DESCRIPTION
This modifies the speech API to allow getting the bytes directly to play.

This will allow platforms like web which cannot write files to play the audio, and will allow other platforms to play the audio without adding file system permissions to write the temporary files.


tests as working with code:

```

    var audio = await OpenAI.instance.audio.createSpeechBytes(
        model: "tts-1",
        input: "message",
        voice: "fable",
        responseFormat: OpenAIAudioSpeechResponseFormat.mp3);

  var audioPlayer = AudioPlayer();

  await audioPlayer.play(BytesSource(audio, mimeType: 'audio/mpeg'));
```