### PR TITLE
fix: `/chat` body compatibility

### DIFF
--- a/lib/src/core/models/chat/sub_models/choices/sub_models/message.dart
+++ b/lib/src/core/models/chat/sub_models/choices/sub_models/message.dart
@@ -64,9 +64,15 @@ final class OpenAIChatCompletionChoiceMessageModel {
 
 // This method used to convert the [OpenAIChatCompletionChoiceMessageModel] to a [Map<String, dynamic>] object.
   Map<String, dynamic> toMap() {
+    final content_ = () {
+      if (content?.length == 1) return content?.first.toMap(single: true);
+
+      return content?.map((contentItem) => contentItem.toMap()).toList();
+    }();
+
     return {
       "role": role.name,
-      "content": content?.map((contentItem) => contentItem.toMap()).toList(),
+      "content": content_,
       if (toolCalls != null && role == OpenAIChatMessageRole.assistant)
         "tool_calls": toolCalls!.map((toolCall) => toolCall.toMap()).toList(),
       if (name != null) "name": name,

--- a/lib/src/core/models/chat/sub_models/choices/sub_models/sub_models/content.dart
+++ b/lib/src/core/models/chat/sub_models/choices/sub_models/sub_models/content.dart
@@ -65,13 +65,15 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
   }
 
   /// This method used to convert the [OpenAIChatCompletionChoiceMessageContentItemModel] to a [Map<String, dynamic>] object.
-  Map<String, dynamic> toMap() {
+  Object? toMap({bool single = false}) {
+    if (text != null && single) return text;
+
     return {
       "type": type,
       if (text != null) "text": text,
       if (imageUrl != null) "image_url": imageUrl,
       if (imageBase64 != null)
-        "image_url": {"url": "data:image/jpeg;base64,${imageBase64}"}
+        "image_url": {"url": "data:image/jpeg;base64,${imageBase64}"},
     };
   }
 


### PR DESCRIPTION
As the [OpenAI API ref](https://platform.openai.com/docs/api-reference/chat/create), the body of `/chat/completions` can be:
```json
{
  "model": "gpt-4o",
  "messages": [
    {
      "role": "system",
      "content": "You are a helpful assistant."
    },
    {
      "role": "user",
      "content": "Hello!"
    }
  ]
}
```

In this example, the `messages[0].content` is String, not `{"type": text, "content": ""}`.

Some third-party API forward provider (such as `deepseek`) use this example struct as the only correct struct, without supporting the struct now implemented in this package.

I have made a change as follow: If `messages[INDEX].content` only has one child of type `text`, then the content will set as a string.

Thanks for your review.
:)