### PR TITLE
Add stream_options property to get token usage.

### DIFF
--- a/lib/src/core/models/chat/stream/chat.dart
+++ b/lib/src/core/models/chat/stream/chat.dart
@@ -1,6 +1,6 @@
 import 'package:collection/collection.dart';
 
-import 'sub_models/choices/choices.dart';
+import 'sub_models/usage.dart';
 
 export 'sub_models/choices/choices.dart';
 export 'sub_models/usage.dart';
@@ -20,6 +20,9 @@ final class OpenAIStreamChatCompletionModel {
 
   /// This fingerprint represents the backend configuration that the model runs with.
   final String? systemFingerprint;
+
+  /// An optional field that will only be present when you set `streamOptions: {"include_usage": true}` in your request. When present, it contains a null value except for the last chunk which contains the token usage statistics for the entire request.
+  final OpenAIStreamChatCompletionUsageModel? usage;
 
   /// Wether the chat completion have at least one choice in [choices].
   bool get haveChoices => choices.isNotEmpty;
@@ -41,6 +44,7 @@ final class OpenAIStreamChatCompletionModel {
     required this.created,
     required this.choices,
     required this.systemFingerprint,
+    this.usage,
   });
 
   /// {@macro openai_stream_chat_completion}
@@ -55,6 +59,9 @@ final class OpenAIStreamChatCompletionModel {
           )
           .toList(),
       systemFingerprint: json['system_fingerprint'],
+      usage: json['usage'] != null
+          ? OpenAIStreamChatCompletionUsageModel.fromMap(json['usage'])
+          : null,
     );
   }
 

--- a/lib/src/instance/chat/chat.dart
+++ b/lib/src/instance/chat/chat.dart
@@ -180,6 +180,7 @@ interface class OpenAIChat implements OpenAIChatBase {
     int? seed,
     String? user,
     http.Client? client,
+    Map<String, dynamic>? streamOptions,
   }) {
     return OpenAINetworkingClient.postStream<OpenAIStreamChatCompletionModel>(
       to: BaseApiUrlBuilder.build(endpoint),
@@ -201,6 +202,7 @@ interface class OpenAIChat implements OpenAIChatBase {
         if (user != null) "user": user,
         if (seed != null) "seed": seed,
         if (responseFormat != null) "response_format": responseFormat,
+        if (streamOptions != null && streamOptions.isNotEmpty) "stream_options": streamOptions,
       },
       onSuccess: (Map<String, dynamic> response) {
         return OpenAIStreamChatCompletionModel.fromMap(response);

--- a/test/openai_test.dart
+++ b/test/openai_test.dart
@@ -331,6 +331,9 @@ void main() async {
     test('create with a stream', () async {
       final chatStream = OpenAI.instance.chat.createStream(
         model: "gpt-3.5-turbo",
+        streamOptions: {
+          "include_usage": true,
+        },
         messages: [
           OpenAIChatCompletionChoiceMessageModel(
             content: [
@@ -352,6 +355,13 @@ void main() async {
               isA<List<OpenAIChatCompletionChoiceMessageContentItemModel>?>());
           expect(streamEvent.choices.first.delta.content?.first?.text,
               isA<String?>());
+          if (streamEvent.usage != null) {
+            final u = streamEvent.usage!;
+            expect(u, isA<OpenAIStreamChatCompletionUsageModel>());
+            expect(u.promptTokens, greaterThan(0));
+            expect(u.completionTokens, greaterThan(0));
+            expect(u.totalTokens, equals(u.promptTokens + u.completionTokens));
+          }
         },
         onDone: () {
           completer.complete(true);


### PR DESCRIPTION
Added the ability to receive token usage based on this object in the OpenAI documentation:

https://platform.openai.com/docs/api-reference/chat/streaming

Added an optional parameter called `streamOptions` to the `createStream ` interface which passes the aforementioned body parameter to the chat endpoint which enables receiving the optional usage statistics.

Added tests as well which succeeded during my tests. Some of the new tests might be considered unnecessary and I will be happy to change them if necessary. 

Unrelated to the changes I made - I will note the following `expect`s failed so I commented them out during my testing - they don't seem related to this code:

        expect(streamEvent.choices.first.delta.content,
              isA<List<OpenAIChatCompletionChoiceMessageContentItemModel>?>());
          expect(streamEvent.choices.first.delta.content?.first?.text,
              isA<String?>());

Kept getting `bad state: no element` - presumably because we are using the `.first` getter here. 

Thanks!