### PR TITLE
feat: Support dynamic responseFormat

### DIFF
--- a/lib/src/core/base/chat/interfaces/create.dart
+++ b/lib/src/core/base/chat/interfaces/create.dart
@@ -19,7 +19,7 @@ abstract class CreateInterface {
     Map<String, dynamic>? logitBias,
     String? user,
     http.Client? client,
-    Map<String, String>? responseFormat,
+    Map<String, dynamic>? responseFormat,
     int? seed,
   });
 
@@ -36,7 +36,7 @@ abstract class CreateInterface {
     double? presencePenalty,
     double? frequencyPenalty,
     Map<String, dynamic>? logitBias,
-    Map<String, String>? responseFormat,
+    Map<String, dynamic>? responseFormat,
     String? user,
     http.Client? client,
     int? seed,
@@ -57,7 +57,7 @@ abstract class CreateInterface {
     Map<String, dynamic>? logitBias,
     String? user,
     http.Client? client,
-    Map<String, String>? responseFormat,
+    Map<String, dynamic>? responseFormat,
     int? seed,
   });
 }

--- a/lib/src/instance/chat/chat.dart
+++ b/lib/src/instance/chat/chat.dart
@@ -80,7 +80,7 @@ interface class OpenAIChat implements OpenAIChatBase {
     double? frequencyPenalty,
     Map<String, dynamic>? logitBias,
     String? user,
-    Map<String, String>? responseFormat,
+    Map<String, dynamic>? responseFormat,
     int? seed,
     bool? logprobs,
     int? topLogprobs,
@@ -176,7 +176,7 @@ interface class OpenAIChat implements OpenAIChatBase {
     double? presencePenalty,
     double? frequencyPenalty,
     Map<String, dynamic>? logitBias,
-    Map<String, String>? responseFormat,
+    Map<String, dynamic>? responseFormat,
     int? seed,
     String? user,
     http.Client? client,
@@ -225,7 +225,7 @@ interface class OpenAIChat implements OpenAIChatBase {
     Map<String, dynamic>? logitBias,
     String? user,
     http.Client? client,
-    Map<String, String>? responseFormat,
+    Map<String, dynamic>? responseFormat,
     int? seed,
   }) {
     return OpenAINetworkingClient.postStream<OpenAIStreamChatCompletionModel>(


### PR DESCRIPTION
OpenAI recently introduced Structured outputs in their API. This is done by passing the desired JSON schema in the "response_format" parameter as described here: https://openai.com/index/introducing-structured-outputs-in-the-api/

Since the JSON schema is an object i.e. Map<String, dynamic> and not a String, we should remove the type requirement for "response_format" and use dynamic instead, similar to "logitBias"