### PR TITLE
Add timeout to postStream API

### DIFF
--- a/lib/src/core/networking/client.dart
+++ b/lib/src/core/networking/client.dart
@@ -354,7 +354,7 @@ abstract class OpenAINetworkingClient {
 
       OpenAILogger.logStartRequest(to);
       try {
-        final respond = await clientForUse.send(request);
+        final respond = await clientForUse.send(request).timeout(OpenAIConfig.requestsTimeOut);
 
         try {
           OpenAILogger.startReadStreamResponse();


### PR DESCRIPTION
There was a case where a deadlock occurred because a timeout was not assigned to postStream, so this has been fixed.