### PR TITLE
fix(model): image_url changed to object from string as specified in OpenAI API spec

### DIFF
--- a/lib/src/core/models/chat/sub_models/choices/sub_models/sub_models/content.dart
+++ b/lib/src/core/models/chat/sub_models/choices/sub_models/sub_models/content.dart
@@ -69,7 +69,7 @@ class OpenAIChatCompletionChoiceMessageContentItemModel {
     return {
       "type": type,
       if (text != null) "text": text,
-      if (imageUrl != null) "image_url": imageUrl,
+      if (imageUrl != null) "image_url": { "url": imageUrl },
       if (imageBase64 != null)
         "image_url": {"url": "data:image/jpeg;base64,${imageBase64}"}
     };


### PR DESCRIPTION
I noticed the request Exception below and went searching. 

As discussed in the openai community forum [here](https://community.openai.com/t/image-url-for-gpt-4o-api-giving-error-expected-an-object-but-got-a-string-instead/748188) The `image_url` should be an object and not a string. In the current implementation, the `image_url` will be set as a string and this will always result in the following response from the openai api:
```
RequestFailedException(message: Invalid type for 'messages[1].content[0].image_url': expected an object, but got a string instead
```

In the forum discussion, it is mentioned that the api specs were outdated, but its not anymore as specified under the image tab at the [openai chat completion api spec](https://platform.openai.com/docs/api-reference/chat/create)