### PR TITLE
Update responseFormat type

### DIFF
--- a/lib/src/instance/chat/chat.dart
+++ b/lib/src/instance/chat/chat.dart
@@ -80,7 +80,7 @@ interface class OpenAIChat implements OpenAIChatBase {
     double? frequencyPenalty,
     Map<String, dynamic>? logitBias,
     String? user,
-    Map<String, String>? responseFormat,
+    Map<String, dynamic>? responseFormat,
     int? seed,
     bool? logprobs,
     int? topLogprobs,


### PR DESCRIPTION
Hi, thanks for your work!

According to OpenAI’s [specification](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format),
the _json_schema_ field should be an object (Map<String, dynamic> in dart). However, due to the implementation, it was only possible to pass a string. Therefore, it’s better to make it dynamic.