### PR TITLE
Add previous_response_id to response mapping (response API)

### DIFF
--- a/lib/src/instance/responses/responses.dart
+++ b/lib/src/instance/responses/responses.dart
@@ -57,6 +57,7 @@ class OpenAIResponses extends OpenAIResponsesBase {
         if (metadata != null) "metadata": metadata,
         if (model != null) "model": model,
         if (parallelToolCalls != null) "parallel_tool_calls": parallelToolCalls,
+        if (previousResponseId != null) "previous_response_id": previousResponseId,
         if (prompt != null) "prompt": prompt,
         if (promptCacheKey != null) "prompt_cache_key": promptCacheKey,
         if (reasoning != null) "reasoning": reasoning,


### PR DESCRIPTION
I tried using the conversation state and that didn't work. Eventually I noticed you just for pass that field on. Thanks for all the good work.